### PR TITLE
Add nfs_export LWRP to work in tandem with node['nfs']['exports']

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ ATTRIBUTES
 
 * nfs['exports']
 
-  - This may be replaced in the future by an LWRP to load export definitions from
-    a data bag.  For now, its a simple array of strings to populate in an export file.
-    Note: The "nfs::exports" recipe is separate from the "nfs::server" recipe.
+  - An array of strings to populate in an export file. Can be manipulated in
+    recipes with the nfs_export LWRP.
 
 USAGE
 =====
@@ -66,7 +65,16 @@ Then in an nfs\_server.rb role that is applied to NFS servers:
         ]
       }
     )
-    run_list => [ "nfs::server", "nfs::exports" ]
+    run_list => [ "nfs::server" ]
+
+Applications or other cookbooks can setup exports with nfs_export:
+
+    nfs_export "/foobar" do
+      network '*'
+      writeable true
+      sync false
+      extra_options ['no_root_squash']
+    end
 
 LICENSE AND AUTHOR
 ==================

--- a/providers/export.rb
+++ b/providers/export.rb
@@ -1,0 +1,22 @@
+def load_current_resource
+  @export = Chef::Resource::NfsExport.new(new_resource.directory)
+  Chef::Log.debug("Checking whether #{new_resource.directory} is already an NFS export")
+  @export.exists node['nfs']['exports'].detect {|x| x.match "^#{new_resource.directory}" }
+end
+
+action :create do
+  unless @export.exists
+    ro_rw = new_resource.writeable ? "rw" : "ro"
+    sync_async = new_resource.sync ? "sync" : "async"
+    extra_options = new_resource.extra_options.join(',')
+    extra_options = ",#{extra_options}" unless extra_options == ""
+    export = "#{new_resource.directory} #{new_resource.network}(#{ro_rw},#{sync_async}#{extra_options})"
+    node['nfs']['exports'] << export
+    execute "notify_export_create" do
+      command "/bin/true"
+      notifies :create, resources("template[/etc/exports]")
+      action :run
+    end
+    new_resource.updated_by_last_action(true)
+  end
+end

--- a/recipes/exports.rb
+++ b/recipes/exports.rb
@@ -22,9 +22,13 @@ execute "exportfs" do
   action :nothing
 end
 
-unless node["nfs"]["exports"].empty?
-  template "/etc/exports" do
-     mode 0644
-     notifies :run, "execute[exportfs]"
-  end
+template "/etc/exports" do
+  mode 0644
+  notifies :run, "execute[exportfs]"
+  action :nothing
+end
+
+execute "/bin/true" do
+  not_if { node["nfs"]["exports"].empty? }
+  notifies :create, "template[/etc/exports]"
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -18,6 +18,7 @@
 #
 
 include_recipe "nfs"
+include_recipe "nfs::exports"
 
 # Install server components for Debian
 case node["platform"]

--- a/resources/export.rb
+++ b/resources/export.rb
@@ -1,0 +1,14 @@
+def initialize(*args)
+  super
+  @action = :create
+end
+
+actions :create
+
+attribute :directory, :name_attribute => true
+attribute :network, :required
+attribute :writeable, :default => false, :kind_of => [TrueClass, FalseClass]
+attribute :sync, :default => true, :kind_of => [TrueClass, FalseClass]
+attribute :extra_options, :default => ['root_squash'], :kind_of => Array
+
+attribute :exists, :kind_of => [TrueClass, FalseClass]


### PR DESCRIPTION
App cookbooks may need to create their own exports.

```
nfs_export "/foobar" do
  network '*'
  writeable true
  sync false
  extra_options ['no_root_squash']
end
```
