### PR TITLE
Changing attribute type for ['nfs']['config']['server_template']

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,7 +45,7 @@ when "ubuntu","debian"
   default['nfs']['service']['lock'] = "statd"
   default['nfs']['service']['server'] = "nfs-kernel-server"
   default['nfs']['config']['client_templates'] = %w{ /etc/default/nfs-common /etc/modprobe.d/lockd.conf }
-  default['nfs']['config']['server_template'] = %w{ /etc/default/nfs-kernel-server }
+  default['nfs']['config']['server_template'] = "/etc/default/nfs-kernel-server"
 
   # Ubuntu 11+ edge case package set and portmap name
   if node['platform_version'].to_i >= 11


### PR DESCRIPTION
I ran into an issue using this cookbook with Vagrant and the precise32.box (Ubuntu 12.04, Chef 10.10, Ruby 1.8.7-p352). When trying to run the nfs::server recipe, the Chef run would error out with the message "TypeError: can't convert Array into String". Changing this attribute to a string fixed the issue for me.
