### PR TITLE
Debian Wheezy compatibility

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,7 +65,7 @@ when "debian"
   end
 
   # Debian 7.0+ (wheezy)
-  if node['platform'] == "debian" and node['lsb']['codename'] == "wheezy"
+  if node['platform'] == "debian" and node['platform_version'].to_i >= 7
     default['nfs']['service']['portmap'] = "rpcbind"
   end
 


### PR DESCRIPTION
Debian Wheezy uses rpcbind instead of portmap.
