### PR TITLE
Providing the ability to turn off certain versions of NFS.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,10 @@
 # limitations under the License.
 #
 
+#Allowing Version 2 and Version 3 of NFS to be enabled or disabled.  Both are enabled by default.
+default['nfs']['v2'] = "yes"
+default['nfs']['v3'] = "yes"
+
 # Default options are taken from the Debian guide on static NFS ports
 default['nfs']['port']['statd'] = 32765
 default['nfs']['port']['statd_out'] = 32766

--- a/templates/default/nfs.erb
+++ b/templates/default/nfs.erb
@@ -5,4 +5,6 @@ STATD_OUTGOING_PORT=<%= node["nfs"]["port"]["statd_out"] %>
 MOUNTD_PORT=<%= node["nfs"]["port"]["mountd"] %>
 LOCKD_UDPPORT=<%= node["nfs"]["port"]["lockd"] %>
 LOCKD_TCPPORT=<%= node["nfs"]["port"]["lockd"] %>
+MOUNTD_NFS_V2=<%= node["nfs"]["v2"] %>
+MOUNTD_NFS_V3=<%= node["nfs"]["v3"] %>
 RQUOTAD="no"


### PR DESCRIPTION
My organization requires that we disable NFS Version 2.  I left both enabled by default because it is then a non-breaking change.
