### PR TITLE
Add kitchen tests for Debian debian-7.2.0

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,10 @@ driver_config:
   require_chef_omnibus: latest
 
 platforms:
+- name: debian-7.2.0
+  driver_config:
+    box: opscode-debian-7.2.0
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_debian-7.2.0_provisionerless.box
 - name: ubuntu-12.04 
   run_list:
   - recipe[apt]


### PR DESCRIPTION
Add debian-7.2.0 to the list of platforms tested by "kitchen test".

cookbook-nfs now handles Debian wheezy but the kitchen tests do not test using Debian.  This commit just adds debian-7.2.0 to the list of test platforms.
