### PR TITLE
Support for Ubuntu 13.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Should work on any Red Hat-family and Debian-family or Suse Sles Linux distribut
   - lock - the statd or nfslock service depending on platform
   - server - the server component, nfs or nfs-kernel-server depending on platform
 
+* nfs['service\_provider']
+  - portmap - provider for portmap service, chosen by platform
+  - lock - provider for lock service, chosen by platform
+  - server - provider for server service, chosen by platform
+
 * nfs['config']
   - client\_templates - templates to iterate through on client systems, chosen by platform
   - server\_template - server specific template, chosen by platform

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,8 +33,12 @@ default['nfs']['packages'] = %w{ nfs-utils portmap }
 default['nfs']['service']['portmap'] = "portmap"
 default['nfs']['service']['lock'] = "nfslock"
 default['nfs']['service']['server'] = "nfs"
+default['nfs']['service_provider']['lock'] = Chef::Platform::find_provider_for_node node, :service
+default['nfs']['service_provider']['portmap'] = Chef::Platform::find_provider_for_node node, :service
+default['nfs']['service_provider']['server'] = Chef::Platform::find_provider_for_node node, :service
 default['nfs']['config']['client_templates'] = %w{ /etc/sysconfig/nfs }
 default['nfs']['config']['server_template'] = "/etc/sysconfig/nfs"
+
 
 case node['platform_family']
 
@@ -72,6 +76,12 @@ when 'debian'
     elsif node['platform_version'].to_f >= 11.10 
       default['nfs']['service']['portmap'] = "rpcbind-boot"
       default['nfs']['packages'] = %w{ nfs-common rpcbind }
+    end
+
+    # Ubuntu 13.10+ service provider is Upstart for portmap and lock
+    if node['platform_version'].to_f >= 13.10
+      default['nfs']['service_provider']['portmap'] = Chef::Provider::Service::Upstart
+      default['nfs']['service_provider']['lock'] = Chef::Provider::Service::Upstart
     end
 
   when 'debian'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,12 +34,14 @@ end
 # Start NFS client components
 service "portmap" do
   service_name node['nfs']['service']['portmap']
+  provider node['nfs']['service_provider']['portmap']
   action [ :start, :enable ]
   supports :status => true
 end
 
 service "nfslock" do
   service_name node['nfs']['service']['lock']
+  provider node['nfs']['service_provider']['lock']
   action [ :start, :enable ]
   supports :status => true
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -27,6 +27,7 @@ end
 
 # Start nfs-server components
 service node['nfs']['service']['server'] do
+  provider node['nfs']['service_provider']['server']
   action [ :start, :enable ]
   supports :status => true
 end


### PR DESCRIPTION
The lock and portmap services no longer include SysVInit scripts in Ubuntu 13.10 (saucy).  This fixes #30 by using Upstart when the platform is Ubuntu 13.10 or higher.
