### PR TITLE
making notifies :immediately

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,8 +33,8 @@ end
 node['nfs']['config']['client_templates'].each do |client_template|
   template client_template do
     mode 00644
-    notifies :restart, 'service[portmap]'
-    notifies :restart, 'service[nfslock]'
+    notifies :restart, 'service[portmap]', :immediately
+    notifies :restart, 'service[nfslock]', :immediately
   end
 end
 


### PR DESCRIPTION
My mount resource on `my_recipe` fails with the following run_list, which is likely because `:restart, 'service[portmap]'` and `:restart, 'service[nfslock]'` are executed after `mount` in my_recipe. And, adding `:immediately` on the `notifies :restart`s of the `nfs::default` fixed the issue. 

```
{
  "run_list": [
    "role[nfs_base]",
    "recipe[my_recipe]"
  ]
}
```

Not sure if the issue is local to my environment. My chef version is 11.10.4.
