### PR TITLE
Set the nfslock service name for CentOS 7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,6 +63,8 @@ when 'rhel'
   if node['platform_version'].to_i <= 5
     default['nfs']['packages'] = %w(nfs-utils portmap)
     default['nfs']['service']['portmap'] = 'portmap'
+  elsif node['platform_version'].to_i >= 7
+    default['nfs']['service']['lock'] = 'nfs-lock'
   end
 
 when 'freebsd'


### PR DESCRIPTION
In CentOS 7 (and probably rhel 7) the NFS Lock service name changed to nfs-lock.