### PR TITLE
Update _common.rb

### DIFF
--- a/recipes/_common.rb
+++ b/recipes/_common.rb
@@ -45,5 +45,6 @@ end
     provider node['nfs']['service_provider'][component]
     action [:start, :enable]
     supports :status => true
+    not_if "service #{component} status | grep -q running"
   end
 end


### PR DESCRIPTION
This gets rid of the green action line stating that it is starting the service when it really is doing nothing.