### PR TITLE
fix for issue 45 - on SLES init script will evaluate to start or not

### DIFF
--- a/templates/default/nfs.erb
+++ b/templates/default/nfs.erb
@@ -31,6 +31,7 @@ MOUNTD_PORT="<%= node['nfs']['port']['mountd'] -%>"
 STATD_PORT="<%= node['nfs']['port']['statd'] -%>"
 LOCKD_TCPPORT="<%= node['nfs']['port']['lockd'] -%>"
 LOCKD_UDPPORT="<%= node['nfs']['port']['lockd'] -%>"
+NFS_START_SERVICES="yes"
   <% unless node['nfs']['v4'].nil? -%>
 NFS4_SUPPORT="<%= node['nfs']['v4'] -%>"
   <% end -%>


### PR DESCRIPTION
if no fstab nfs entries, client will fail to start, failing chef run too
adding variable to force starting