### PR TITLE
avoid recipe compile error on Windows

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,25 +36,27 @@ default['nfs']['port']['rquotad'] = 32_769
 # Number of rpc.nfsd threads to start (default 8)
 default['nfs']['threads'] = 8
 
-# Default options are based on RHEL6
-default['nfs']['packages'] = %w(nfs-utils rpcbind)
-default['nfs']['service']['portmap'] = 'rpcbind'
-default['nfs']['service']['lock'] = 'nfslock'
-default['nfs']['service']['server'] = 'nfs'
-default['nfs']['service_provider']['lock'] = Chef::Platform.find_provider_for_node node, :service
-default['nfs']['service_provider']['portmap'] = Chef::Platform.find_provider_for_node node, :service
-default['nfs']['service_provider']['server'] = Chef::Platform.find_provider_for_node node, :service
-default['nfs']['config']['client_templates'] = %w(/etc/sysconfig/nfs)
-default['nfs']['config']['server_template'] = '/etc/sysconfig/nfs'
+unless node['platform_family'] == 'windows'
+  # Default options are based on RHEL6
+  default['nfs']['packages'] = %w(nfs-utils rpcbind)
+  default['nfs']['service']['portmap'] = 'rpcbind'
+  default['nfs']['service']['lock'] = 'nfslock'
+  default['nfs']['service']['server'] = 'nfs'
+  default['nfs']['service_provider']['lock'] = Chef::Platform.find_provider_for_node node, :service
+  default['nfs']['service_provider']['portmap'] = Chef::Platform.find_provider_for_node node, :service
+  default['nfs']['service_provider']['server'] = Chef::Platform.find_provider_for_node node, :service
+  default['nfs']['config']['client_templates'] = %w(/etc/sysconfig/nfs)
+  default['nfs']['config']['server_template'] = '/etc/sysconfig/nfs'
 
-# idmap recipe attributes
-default['nfs']['config']['idmap_template'] = '/etc/idmapd.conf'
-default['nfs']['service']['idmap'] = 'rpcidmapd'
-default['nfs']['service_provider']['idmap'] = Chef::Platform.find_provider_for_node node, :service
-default['nfs']['idmap']['domain'] = node['domain']
-default['nfs']['idmap']['pipefs_directory'] = '/var/lib/nfs/rpc_pipefs'
-default['nfs']['idmap']['user'] = 'nobody'
-default['nfs']['idmap']['group'] = 'nobody'
+  # idmap recipe attributes
+  default['nfs']['config']['idmap_template'] = '/etc/idmapd.conf'
+  default['nfs']['service']['idmap'] = 'rpcidmapd'
+  default['nfs']['service_provider']['idmap'] = Chef::Platform.find_provider_for_node node, :service
+  default['nfs']['idmap']['domain'] = node['domain']
+  default['nfs']['idmap']['pipefs_directory'] = '/var/lib/nfs/rpc_pipefs'
+  default['nfs']['idmap']['user'] = 'nobody'
+  default['nfs']['idmap']['group'] = 'nobody'
+end
 
 case node['platform_family']
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,7 +36,7 @@ default['nfs']['port']['rquotad'] = 32_769
 # Number of rpc.nfsd threads to start (default 8)
 default['nfs']['threads'] = 8
 
-unless node['platform_family'] == 'windows'
+unless node['platform_family'] == 'windows' or node['platform_family'] == 'solaris2'
   # Default options are based on RHEL6
   default['nfs']['packages'] = %w(nfs-utils rpcbind)
   default['nfs']['service']['portmap'] = 'rpcbind'


### PR DESCRIPTION
Currently the NFS cookbook causes recipe compile error on Windows, even if the cookbook is not used and just a transitive dependency of some other cookbook.

```
================================================================================
Recipe Compile Error in C:/chef/cache/cookbooks/nfs/attributes/default.rb
================================================================================

ArgumentError
-------------
Cannot find a provider for service on windows version 6.1.7601

Cookbook Trace:
---------------
  C:/opscode/chef/embedded/apps/chef/lib/chef/platform/provider_mapping.rb:446:in `find_provider'
  C:/opscode/chef/embedded/apps/chef/lib/chef/platform/provider_mapping.rb:373:in `find_provider_for_node'
  C:/chef/cache/cookbooks/nfs/attributes/default.rb:44:in `from_file'
```