### PR TITLE
Fix for Amazon Linux EC2 instances with 'platform' = 'amazon'.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,20 +59,27 @@ default['nfs']['client-services'] = %w(portmap lock)
 case node['platform_family']
 
 when 'rhel'
-  # RHEL5 edge case package set and portmap name
-  if node['platform_version'].to_i <= 5
-    default['nfs']['packages'] = %w(nfs-utils portmap)
-    default['nfs']['service']['portmap'] = 'portmap'
-  elsif node['platform_version'].to_i >= 7
-    default['nfs']['service']['lock'] = 'nfs-lock'
-    default['nfs']['service']['server'] = 'nfs-server'
-    default['nfs']['service']['idmap'] = 'nfs-idmap'
-
-    if node['platform_version'] == '7.0.1406'
-      default['nfs']['client-services'] = %w(nfs-lock.service)
+  case node['platform']
+    when 'amazon'
+      default['nfs']['service']['lock'] = 'nfslock'
+      default['nfs']['service']['server'] = 'nfs'
+      default['nfs']['service']['idmap'] = 'rpcidmapd'
     else
-      default['nfs']['client-services'] = %w(nfs-client.target)
-    end
+      # RHEL5 edge case package set and portmap name
+      if node['platform_version'].to_i <= 5
+        default['nfs']['packages'] = %w(nfs-utils portmap)
+        default['nfs']['service']['portmap'] = 'portmap'
+      elsif node['platform_version'].to_i >= 7
+        default['nfs']['service']['lock'] = 'nfs-lock'
+        default['nfs']['service']['server'] = 'nfs-server'
+        default['nfs']['service']['idmap'] = 'nfs-idmap'
+
+        if node['platform_version'] == '7.0.1406'
+          default['nfs']['client-services'] = %w(nfs-lock.service)
+        else
+          default['nfs']['client-services'] = %w(nfs-client.target)
+        end
+      end
   end
 
 when 'freebsd'


### PR DESCRIPTION
Linuxt instances in Amazon AWS have next platform identification:
platform_family = rhel
platform = amazon
platform_version = 2015.03

In this case you NFS cookbook fails during node setup process. Here the failure log:
[2015-07-09T09:20:33+00:00] INFO: Processing service[nfs-client.target] action restart (nfs::_common line 46)
 
'============================================================================
Error executing action `restart` on resource 'service[nfs-client.target]'
'============================================================================
 
 
Chef::Exceptions::Service
'-------------------------
service[nfs-client.target]: unable to locate the init.d script!
 
 
Resource Declaration:
'---------------------
'# In /var/lib/aws/opsworks/cache.stage2/cookbooks/nfs/recipes/_common.rb
 
46:   service component do
47:     service_name node['nfs']['service'][component]
48:     provider node['nfs']['service_provider'][component] if node['platform'] == 'ubuntu'
49:     # not_if "service #{component} status | grep -q running"
50:     action [:start, :enable]
51:     # supports :status => true
52:   end
53: end

Compiled Resource:
'------------------
'# Declared in /var/lib/aws/opsworks/cache.stage2/cookbooks/nfs/recipes/_common.rb:46:in `block in from_file'
 
service("nfs-client.target") do
action [:start, :enable]
supports {:restart=>false, :reload=>false, :status=>true}
retries 0
retry_delay 2
service_name "nfs-client.target"
pattern "nfs-client.target"
cookbook_name "nfs"
recipe_name "_common"
end

You looking only on platform_family which is really rhel. But version is 2015. In this case we have next variables values:
          default['nfs']['service']['lock'] = 'nfs-lock'
          default['nfs']['service']['server'] = 'nfs-server'
          default['nfs']['service']['idmap'] = 'nfs-idmap'
         default['nfs']['client-services'] = %w(nfs-client.target)

This service names completely wrong for 'amazon linux' operating system. Right daemon names is
        default['nfs']['service']['lock'] = 'nfslock'
        default['nfs']['service']['server'] = 'nfs'
        default['nfs']['service']['idmap'] = 'rpcidmapd'

Thank you!