### PR TITLE
Fix `export` resource for Chef 12.5.1 compatibility

### DIFF
--- a/resources/export.rb
+++ b/resources/export.rb
@@ -25,7 +25,7 @@ end
 actions :create
 
 attribute :directory, :name_attribute => true
-attribute :network, :required
+attribute :network, :required => true
 attribute :writeable, :default => false, :kind_of => [TrueClass, FalseClass]
 attribute :sync, :default => true, :kind_of => [TrueClass, FalseClass]
 attribute :options, :default => ['root_squash'], :kind_of => Array


### PR DESCRIPTION
Compilation fails under Chef 12.5.1 (worked fine in 12.3.1)

```
================================================================================
       Recipe Compile Error in /tmp/kitchen/cookbooks/nfs_test/recipes/issue46.rb
       ================================================================================

       Chef::Exceptions::ValidationFailed

       Option network must be one of: required!  You passed "127.0.0.1".

       Cookbook Trace:
       ---------------
         /tmp/kitchen/cookbooks/nfs_test/recipes/issue46.rb:11:in `block in from_file'
```

This fix works for me