### PR TITLE
Correct portmap/rpcbind service names for Ubuntu

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -121,7 +121,7 @@ when 'debian'
   case node['platform']
 
   when 'ubuntu'
-    default['nfs']['service']['portmap'] = 'rpcbind-boot'
+    default['nfs']['service']['portmap'] = 'rpcbind'
     default['nfs']['service']['lock'] = 'statd' # There is no lock service on Ubuntu
     default['nfs']['service']['idmap'] = 'idmapd'
     default['nfs']['idmap']['pipefs_directory'] = '/run/rpc_pipefs'
@@ -129,10 +129,9 @@ when 'debian'
     default['nfs']['service_provider']['portmap'] = Chef::Provider::Service::Upstart
     default['nfs']['service_provider']['lock'] = Chef::Provider::Service::Upstart
 
-    # Ubuntu 11.04 and 14.04 service script edge cases
-    if node['platform_version'].to_f <= 11.04 ||
-       node['platform_version'].to_f >= 14.04
-      default['nfs']['service']['portmap'] = 'rpcbind'
+    # Ubuntu 13.04 and earlier service name = 'portmap'
+    if node['platform_version'].to_f <= 13.04
+      default['nfs']['service']['portmap'] = 'portmap'
     end
   end
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -131,6 +131,7 @@ when 'debian'
 
     # Ubuntu 13.04 and earlier service name = 'portmap'
     if node['platform_version'].to_f <= 13.04
+      default['nfs']['packages'] = %w(nfs-common portmap)
       default['nfs']['service']['portmap'] = 'portmap'
     end
   end

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -156,7 +156,7 @@ describe 'nfs::_common' do
       expect(chef_run).to render_file('/etc/modprobe.d/lockd.conf').with_content(/options +lockd +nlm_udpport=32768 +nlm_tcpport=32768/)
     end
 
-    %w(portmap statd).each do |svc|
+    %w(rpcbind statd).each do |svc|
       it "starts the #{svc} service" do
         expect(chef_run).to start_service(svc)
       end
@@ -173,7 +173,7 @@ describe 'nfs::_common' do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: 12.04).converge(described_recipe)
     end
 
-    %w(nfs-common rpcbind).each do |pkg|
+    %w(nfs-common portmap).each do |pkg|
       it "installs package #{pkg}" do
         expect(chef_run).to install_package(pkg)
       end
@@ -187,7 +187,7 @@ describe 'nfs::_common' do
       expect(chef_run).to render_file('/etc/modprobe.d/lockd.conf').with_content(/options +lockd +nlm_udpport=32768 +nlm_tcpport=32768/)
     end
 
-    %w(rpcbind-boot statd).each do |svc|
+    %w(portmap statd).each do |svc|
       it "starts the #{svc} service" do
         expect(chef_run).to start_service(svc)
       end
@@ -204,7 +204,7 @@ describe 'nfs::_common' do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: 10.04).converge(described_recipe)
     end
 
-    %w(nfs-common rpcbind).each do |pkg|
+    %w(nfs-common portmap).each do |pkg|
       it "installs package #{pkg}" do
         expect(chef_run).to install_package(pkg)
       end
@@ -218,7 +218,7 @@ describe 'nfs::_common' do
       expect(chef_run).to render_file('/etc/modprobe.d/lockd.conf').with_content(/options +lockd +nlm_udpport=32768 +nlm_tcpport=32768/)
     end
 
-    %w(rpcbind statd).each do |svc|
+    %w(portmap statd).each do |svc|
       it "starts the #{svc} service" do
         expect(chef_run).to start_service(svc)
       end


### PR DESCRIPTION
The correct service name to notify for Ubuntu <=13.04 is not 'rpcbind-boot' but 'portmap', anything newer or equal to 13.10 uses 'rpcbind'.

Without this fix, on a box running Ubuntu 12.04, every Chef run will say:

```
  * service[portmap] action start
    - start service service[portmap]
```
even when the service is running fine. And service rpcbind-boot doesn't do anything:

```
root@box:~# service rpcbind-boot status
rpcbind-boot stop/waiting
root@box:~# service rpcbind-boot start
rpcbind-boot stop/waiting
root@box:~# service rpcbind-boot status
rpcbind-boot stop/waiting
```

Tested on Ubuntu 10.04, 12.04 and 14.04.