### PR TITLE
Fix for Opsworks undefined method `source_url' error

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,8 +5,8 @@ description 'Installs and configures NFS, and NFS exports'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 name 'nfs'
 version '2.2.7'
-source_url 'https://github.com/atomic-penguin/cookbook-nfs'
-issues_url 'https://github.com/atomic-penguin/cookbook-nfs/issues'
+source_url 'https://github.com/atomic-penguin/cookbook-nfs' if respond_to?(:source_url)
+issues_url 'https://github.com/atomic-penguin/cookbook-nfs/issues' if respond_to?(:issues_url)
 
 %w(ubuntu debian redhat centos fedora scientific amazon oracle sles freebsd).each do |os|
   supports os


### PR DESCRIPTION
This resolves these errors on AWS Opsworks:

[2016-04-22T00:58:36+00:00] ERROR: Could not read
/opt/aws/opsworks/current/merged-cookbooks/nfs into a Chef object:
undefined method `source_url' for
#<Chef::Cookbook::Metadata:0x007f46dc61a218>