### PR TITLE
Add disable nfs v4 on Debian,ubuntu

### DIFF
--- a/templates/default/nfs.erb
+++ b/templates/default/nfs.erb
@@ -53,6 +53,10 @@ nfs_server_flags="<%= node['nfs']['server_flags'] -%>"
 # Rendered Debian/Ubuntu template variant
 RPCMOUNTDOPTS="-p <%= node['nfs']['port']['mountd'] %>"
   <% unless node['nfs']['threads'] == 0 -%>
+    <% if node['nfs']['v4'] == 'no' -%>
+RPCNFSDCOUNT="<%= node['nfs']['threads'] -%> --no-nfs-version 4"
+    <% else -%>
 RPCNFSDCOUNT="<%= node['nfs']['threads'] -%>"
+    <% end -%>
   <% end -%>
 <% end -%>


### PR DESCRIPTION
Fix nfs.erb template to disable nfs on Debian, Ubuntu if node['nfs']['v4'] = "no"

