### PR TITLE
Use systemd service provider for Ubuntu >= 15.04

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -149,6 +149,8 @@ when 'debian'
       default['nfs']['service_provider']['idmap'] = Chef::Provider::Service::Systemd
       default['nfs']['service_provider']['portmap'] = Chef::Provider::Service::Systemd
       default['nfs']['service_provider']['lock'] = Chef::Provider::Service::Systemd
+      default['nfs']['service']['lock'] = 'rpc-statd'
+      default['nfs']['service']['idmap'] = 'nfs-idmapd'
     end
   end
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -144,5 +144,11 @@ when 'debian'
       default['nfs']['packages'] = %w(nfs-common portmap)
       default['nfs']['service']['portmap'] = 'portmap'
     end
+
+    if Chef::VersionConstraint.new('>= 15.04').include?(node['platform_version'])
+      default['nfs']['service_provider']['idmap'] = Chef::Provider::Service::Systemd
+      default['nfs']['service_provider']['portmap'] = Chef::Provider::Service::Systemd
+      default['nfs']['service_provider']['lock'] = Chef::Provider::Service::Systemd
+    end
   end
 end

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -156,7 +156,7 @@ describe 'nfs::_common' do
       expect(chef_run).to render_file('/etc/modprobe.d/lockd.conf').with_content(/options +lockd +nlm_udpport=32768 +nlm_tcpport=32768/)
     end
 
-    %w(rpcbind statd).each do |svc|
+    %w(rpcbind rpc-statd).each do |svc|
       it "starts the #{svc} service" do
         expect(chef_run).to start_service(svc)
       end

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -137,6 +137,37 @@ describe 'nfs::_common' do
 =end
 
   # Submit Ubuntu Fauxhai to https://github.com/customink/fauxhai for better Ubuntu coverage
+  context 'on Ubuntu 16.04' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: 16.04).converge(described_recipe)
+    end
+
+    %w(nfs-common rpcbind).each do |pkg|
+      it "installs package #{pkg}" do
+        expect(chef_run).to install_package(pkg)
+      end
+    end
+
+    it 'creates file /etc/default/nfs-common with: STATDOPTS="--port 32765 --outgoing-port 32766' do
+      expect(chef_run).to render_file('/etc/default/nfs-common').with_content(/STATDOPTS="--port +32765 +--outgoing-port +32766"/)
+    end
+
+    it 'creates file /etc/modprobe.d/lockd.conf with: options lockd nlm_udpport=32768 nlm_tcpport=32768' do
+      expect(chef_run).to render_file('/etc/modprobe.d/lockd.conf').with_content(/options +lockd +nlm_udpport=32768 +nlm_tcpport=32768/)
+    end
+
+    %w(rpcbind statd).each do |svc|
+      it "starts the #{svc} service" do
+        expect(chef_run).to start_service(svc)
+      end
+
+      it "enables the #{svc} service" do
+        expect(chef_run).to enable_service(svc)
+      end
+    end
+  end
+
+  # Submit Ubuntu Fauxhai to https://github.com/customink/fauxhai for better Ubuntu coverage
   context 'on Ubuntu 14.04' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: 14.04).converge(described_recipe)

--- a/spec/idmap_spec.rb
+++ b/spec/idmap_spec.rb
@@ -53,7 +53,7 @@ describe 'nfs::_idmap' do
     end
   end
 
-  %w(14.04 12.04 10.04).each do |release|
+  %w(16.04 14.04 12.04 10.04).each do |release|
     context "on Ubuntu #{release}" do
       let(:chef_run) do
         ChefSpec::ServerRunner.new(platform: 'ubuntu', version: release).converge(described_recipe)

--- a/spec/idmap_spec.rb
+++ b/spec/idmap_spec.rb
@@ -71,14 +71,18 @@ describe 'nfs::_idmap' do
         expect(chef_run).to_not install_package('nfs-kernel-server')
       end
 
-      %w(idmapd).each do |nfs|
-        it "starts the #{nfs} service" do
-          expect(chef_run).to start_service(nfs)
-        end
+      if release == '16.04'
+        idmap_svc = 'nfs-idmapd'
+      else
+        idmap_svc = 'idmapd'
+      end
 
-        it "enables the #{nfs} service" do
-          expect(chef_run).to enable_service(nfs)
-        end
+      it "starts the #{idmap_svc} service" do
+        expect(chef_run).to start_service(idmap_svc)
+      end
+
+      it "enables the #{idmap_svc} service" do
+        expect(chef_run).to enable_service(idmap_svc)
       end
     end
   end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -92,7 +92,7 @@ describe 'nfs::server' do
   end
 =end
 
-  %w(14.04 12.04 10.04).each do |release|
+  %w(16.04 14.04 12.04 10.04).each do |release|
     # Submit Ubuntu Fauxhai to https://github.com/customink/fauxhai for better Ubuntu coverage
     context "on Ubuntu #{release}" do
       let(:chef_run) do


### PR DESCRIPTION
This PR adds Ubuntu 16.04 support to the tests, and makes sure we use the systemd service provider on Ubuntu >= 15.04