### PR TITLE
Invalid /etc/defaults/nfs-kernel-server is generated in Debian

### DIFF
--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -30,7 +30,7 @@ describe 'nfs::_common' do
       RPCNFSDCOUNT: 8
     }.each do |svc, port|
       it "creates /etc/sysconfig/nfs with #{svc} defined as #{port}" do
-        expect(chef_run).to render_file('/etc/sysconfig/nfs').with_content(/#{svc}="?#{port}"?/)
+        expect(chef_run).to render_file('/etc/sysconfig/nfs').with_content(/#{svc}="#{port}"/)
       end
     end
   end
@@ -64,7 +64,7 @@ describe 'nfs::_common' do
       RPCNFSDCOUNT: 8
     }.each do |svc, port|
       it "creates /etc/sysconfig/nfs with #{svc} defined as #{port}" do
-        expect(chef_run).to render_file('/etc/sysconfig/nfs').with_content(/#{svc}="?#{port}"?/)
+        expect(chef_run).to render_file('/etc/sysconfig/nfs').with_content(/#{svc}="#{port}"/)
       end
     end
   end
@@ -98,7 +98,7 @@ describe 'nfs::_common' do
       RPCNFSDCOUNT: 8
     }.each do |svc, port|
       it "creates /etc/sysconfig/nfs with #{svc} defined as #{port}" do
-        expect(chef_run).to render_file('/etc/sysconfig/nfs').with_content(/#{svc}="?#{port}"?/)
+        expect(chef_run).to render_file('/etc/sysconfig/nfs').with_content(/#{svc}="#{port}"/)
       end
     end
   end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -137,7 +137,7 @@ describe 'nfs::server' do
     end
 
     it 'creates file /etc/default/nfs-kernel-server with: RPCNFSDCOUNT="8"' do
-      expect(chef_run).to render_file('/etc/default/nfs-kernel-server').with_content(/RPCNFSDCOUNT="?8"?/)
+      expect(chef_run).to render_file('/etc/default/nfs-kernel-server').with_content(/RPCNFSDCOUNT="8"/)
     end
 
     %w(nfs-kernel-server).each do |nfs|
@@ -169,7 +169,7 @@ describe 'nfs::server' do
     end
 
     it 'creates file /etc/default/nfs-kernel-server with: RPCNFSDCOUNT="8"' do
-      expect(chef_run).to render_file('/etc/default/nfs-kernel-server').with_content(/RPCNFSDCOUNT="?8"?/)
+      expect(chef_run).to render_file('/etc/default/nfs-kernel-server').with_content(/RPCNFSDCOUNT="8"/)
     end
 
     %w(nfs-kernel-server).each do |nfs|
@@ -201,7 +201,7 @@ describe 'nfs::server' do
     end
 
     it 'creates file /etc/default/nfs-kernel-server with: RPCNFSDCOUNT="8"' do
-      expect(chef_run).to render_file('/etc/default/nfs-kernel-server').with_content(/RPCNFSDCOUNT="?8"?/)
+      expect(chef_run).to render_file('/etc/default/nfs-kernel-server').with_content(/RPCNFSDCOUNT="8"/)
     end
 
     %w(nfs-kernel-server).each do |nfs|

--- a/templates/default/nfs.erb
+++ b/templates/default/nfs.erb
@@ -53,6 +53,6 @@ nfs_server_flags="<%= node['nfs']['server_flags'] -%>"
 # Rendered Debian/Ubuntu template variant
 RPCMOUNTDOPTS="-p <%= node['nfs']['port']['mountd'] %>"
   <% unless node['nfs']['threads'] == 0 -%>
-RPCNFSDCOUNT="<%= node['nfs']['threads'] -%><% if node['nfs']['v4'] == 'no' -%> --no-nfs-version 4"<% end -%>
+RPCNFSDCOUNT="<%= node['nfs']['threads'] -%><% if node['nfs']['v4'] == 'no' -%> --no-nfs-version 4<% end -%>"
   <% end -%>
 <% end -%>


### PR DESCRIPTION
Hello,

This PR fixes the template `nfs.erb` which generates a invalid line without closing quote in Debian:
``` shell
# /etc/default/nfs-kernel-server @ Ubuntu-14.04
...
RPCNFSDCOUNT="8
```

And also fixes ambiguous specs passing such invalid lines.