### PR TITLE
Add "nfs-config" to client service list for RHEL 7

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,7 @@ platforms:
 - name: ubuntu-12.04
   run_list:
   - recipe[apt]
+- name: centos-7.2
 - name: centos-7.1
 - name: centos-7.0
   driver:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -74,7 +74,7 @@ when 'rhel'
       if node['platform_version'] == '7.0.1406'
         %w(nfs-lock.service)
       else
-        %w(nfs-client.target)
+        %w(nfs-config.service nfs-client.target)
       end
   end
 


### PR DESCRIPTION
It fixes GH-91
Being a part of `nfs-utils` package,`nfs-config` service refreshes the config file need for other NFS-related services. It should be restarted to bring an actual configuration.

In this PR I've also added centos-7.2 suite to `.kitchen.yml`