### PR TITLE
Removing newline character at end of export_line

### DIFF
--- a/providers/export.rb
+++ b/providers/export.rb
@@ -35,9 +35,9 @@ action :create do
 
     if new_resource.network.is_a?(Array)
       host_permissions = new_resource.network.map { |net| net + "(#{ro_rw},#{sync_async}#{options})" }
-      export_line = "#{new_resource.directory} #{host_permissions.join(' ')}\n"
+      export_line = "#{new_resource.directory} #{host_permissions.join(' ')}"
     else
-      export_line = "#{new_resource.directory} #{new_resource.network}(#{ro_rw},#{sync_async}#{options})\n"
+      export_line = "#{new_resource.directory} #{new_resource.network}(#{ro_rw},#{sync_async}#{options})"
     end
 
     execute 'exportfs' do


### PR DESCRIPTION
This is needed because in the "line" cookbook resource "replace_or_add", the value for line is compared to the existing line in the /etc/exports file, but modified with .chomp
```
# line/libraries/provider_replace_or_add.rb
# Lines: 51-55

unless line.chomp == new_resource.line
  line = new_resource.line
  modified = true
end
```
So, when "new_resource.line" ends with a '\n' character, it will never be equal to line.chomp, so it will always be marked as modified = true. When modified is set to true, the resource is declared as updated by the last action, so the line `notifies :run, 'execute[exportfs]', :immediately` will notify execute[exportfs] everytime, even if there was no update to the line.