### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Limitations
+# Agent Notes
 
 ## Package Availability
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'nfs'
+
+run_list 'test::default'
+
+cookbook 'nfs', path: '.'
+cookbook 'line', git: 'https://github.com/sous-chefs/line.git', branch: 'main'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ## Requirements
 
-See [LIMITATIONS.md](LIMITATIONS.md) for package availability and platform constraints.
+See [AGENTS.md](AGENTS.md) for package availability and platform constraints.
 
 This cookbook depends on the [`line` cookbook](https://github.com/sous-chefs/line).
 

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -9,6 +9,7 @@ transport:
 
 provisioner:
   name: dokken
+  policyfile: Policyfile.rb
 
 platforms:
   - name: almalinux-8

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,6 +16,7 @@ provisioner:
   enforce_idempotency: true
   deprecations_as_errors: true
   chef_license: accept-no-persist
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
@@ -35,12 +36,6 @@ platforms:
   - name: ubuntu-22.04
   - name: ubuntu-24.04
 
-x-run_lists:
-  default: &default_run_list
-    - recipe[test::default]
-  server: &server_run_list
-    - recipe[test::server]
-
 x-verifiers:
   default: &default_verifier
     inspec_tests:
@@ -51,9 +46,11 @@ x-verifiers:
 
 suites:
   - name: default
-    run_list: *default_run_list
+    provisioner:
+      named_run_list: default
     verifier: *default_verifier
 
   - name: server
-    run_list: *server_run_list
+    provisioner:
+      named_run_list: server
     verifier: *server_verifier

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 require_relative '../libraries/helpers'
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary
- replace Berkshelf dependency resolution with Policyfile.rb
- use explicit GitHub source for the sous-chefs/line dependency
- update ChefSpec, Kitchen, and Copilot setup to use Policyfile
- move limitations notes into AGENTS.md and remove stale Berksfile references

## Validation
- chef install Policyfile.rb
- chef update Policyfile.rb
- cookstyle
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation
- markdownlint-cli2 "**/*.md"
- yamllint .
- actionlint
- git diff --check
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen diagnose default-ubuntu-2404
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-ubuntu-2404 --destroy=always